### PR TITLE
UTF-8 fixes

### DIFF
--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -37,16 +37,16 @@ class Client(object):
 
         input_json = None
         if input_object is None:
-            input_json = json.dumps(None)
+            input_json = json.dumps(None).encode('utf-8')
             headers['Content-Type'] = 'application/json'
         elif isinstance(input_object, six.string_types):
-            input_json = input_object
+            input_json = input_object.encode('utf-8')
             headers['Content-Type'] = 'text/plain'
         elif isinstance(input_object, bytearray) or isinstance(input_object, bytes):
             input_json = bytes(input_object)
             headers['Content-Type'] = 'application/octet-stream'
         else:
-            input_json = json.dumps(input_object)
+            input_json = json.dumps(input_object).encode('utf-8')
             headers['Content-Type'] = 'application/json'
 
         response = requests.post(self.apiAddress + url, data=input_json, headers=headers, params=query_parameters)

--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ Aside from that you should be able to drop in the newest version of the client. 
 ```bash
 export ALGORITHMIA_API_KEY={{Your API key here}}
 cd Test
+python acl_test.py
+python algo_test.py
 python datadirectorytest.py
-python util.py
+python datafile_test.py
+python utiltest.py
 ```

--- a/Test/algo_test.py
+++ b/Test/algo_test.py
@@ -15,5 +15,31 @@ class AlgoTest(unittest.TestCase):
         self.assertEquals('binary', result.metadata.content_type)
         self.assertEquals(bytearray('foo','utf-8'), result.result)
 
+    def test_text_unicode(self):
+        telephone = u"\u260E"
+
+        #Unicode input to pipe()
+        result1 = self.client.algo('util/Echo').pipe(telephone)
+        self.assertEquals('text', result1.metadata.content_type)
+        self.assertEquals(telephone, result1.result)
+
+        #Unicode return in .result
+        result2 = self.client.algo('util/Echo').pipe(result1.result)
+        self.assertEquals('text', result2.metadata.content_type)
+        self.assertEquals(telephone, result2.result)
+
+    def test_json_unicode(self):
+        telephone = [u"\u260E"]
+
+        #Unicode input to pipe()
+        result1 = self.client.algo('util/Echo').pipe(telephone)
+        self.assertEquals('json', result1.metadata.content_type)
+        self.assertEquals(telephone, result1.result)
+
+        #Unicode return in .result
+        result2 = self.client.algo('util/Echo').pipe(result1.result)
+        self.assertEquals('json', result2.metadata.content_type)
+        self.assertEquals(telephone, result2.result)
+
 if __name__ == '__main__':
     unittest.main()

--- a/Test/algo_test.py
+++ b/Test/algo_test.py
@@ -11,7 +11,7 @@ class AlgoTest(unittest.TestCase):
         self.client = Algorithmia.client(os.environ['ALGORITHMIA_API_KEY'])
 
     def test_call_binary(self):
-        result = self.client.algo('pmcq/Python2xEcho/0.1.0').pipe(bytearray('foo','utf-8'))
+        result = self.client.algo('util/Echo').pipe(bytearray('foo','utf-8'))
         self.assertEquals('binary', result.metadata.content_type)
         self.assertEquals(bytearray('foo','utf-8'), result.result)
 


### PR DESCRIPTION
This should fix the unicode error identified in issue #5.

## After change to client.py:
```
~/algorithmia/algorithmia-python/Test$ python algo_test.py 
...
----------------------------------------------------------------------
Ran 3 tests in 1.013s

OK
```

## Before change to client.py:
```
~/algorithmia/algorithmia-python/Test$ python algo_test.py 
..E
======================================================================
ERROR: test_text_unicode (__main__.AlgoTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "algo_test.py", line 22, in test_text_unicode
    result1 = self.client.algo('util/Echo').pipe(telephone)
  File "/usr/local/lib/python2.7/dist-packages/Algorithmia/algorithm.py", line 39, in pipe
    return AlgoResponse.create_algo_response(self.client.postJsonHelper(self.url, input1, **self.query_parameters))
  File "/usr/local/lib/python2.7/dist-packages/Algorithmia/client.py", line 52, in postJsonHelper
    response = requests.post(self.apiAddress + url, data=input_json, headers=headers, params=query_parameters)
  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 88, in post
    return request('post', url, data=data, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 44, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 455, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 558, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/adapters.py", line 330, in send
    timeout=timeout
  File "/usr/lib/python2.7/dist-packages/urllib3/connectionpool.py", line 562, in urlopen
    body=body, headers=headers)
  File "/usr/lib/python2.7/dist-packages/urllib3/connectionpool.py", line 387, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib/python2.7/httplib.py", line 979, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python2.7/httplib.py", line 1013, in _send_request
    self.endheaders(body)
  File "/usr/lib/python2.7/httplib.py", line 975, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python2.7/httplib.py", line 839, in _send_output
    self.send(message_body)
  File "/usr/lib/python2.7/httplib.py", line 811, in send
    self.sock.sendall(data)
  File "/usr/lib/python2.7/ssl.py", line 329, in sendall
    v = self.send(data[count:])
  File "/usr/lib/python2.7/ssl.py", line 298, in send
    v = self._sslobj.write(data)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u260e' in position 0: ordinal not in range(128)

----------------------------------------------------------------------
Ran 3 tests in 1.776s

FAILED (errors=1)
```