### PR TITLE
[PLATFORM-2464] Fix parsing of datetimes with fractionals

### DIFF
--- a/Algorithmia/datafile.py
+++ b/Algorithmia/datafile.py
@@ -21,7 +21,7 @@ class DataFile(DataObject):
         self.size = None
 
     def set_attributes(self, attributes):
-        self.last_modified = datetime.strptime(attributes['last_modified'],'%Y-%m-%dT%H:%M:%S.000Z')
+        self.last_modified = datetime.strptime(attributes['last_modified'],'%Y-%m-%dT%H:%M:%S.%fZ')
         self.size = attributes['size']
 
     # Deprecated:

--- a/Test/datafile_test.py
+++ b/Test/datafile_test.py
@@ -4,6 +4,7 @@ sys.path.append("../")
 import unittest
 
 import Algorithmia
+from Algorithmia.datafile import DataFile
 
 class DataDirectoryTest(unittest.TestCase):
     def setUp(self):
@@ -26,6 +27,17 @@ class DataDirectoryTest(unittest.TestCase):
         except Exception as e:
             retrieved_file = False
         self.assertFalse(retrieved_file)
+
+    def test_set_attributes(self):
+        df = DataFile(self.client, 'data://.my/empty')
+
+        try:
+            df.set_attributes({
+                'last_modified': '2019-01-09T22:44:31.632Z',
+                'size': 0
+            })
+        except Exception as e:
+            self.fail("set_attributes failed with exception: " + str(e))
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='algorithmia',
-    version='1.1.3',
+    version='1.1.4',
     description='Algorithmia Python Client',
     long_description='Algorithmia Python Client is a client library for accessing Algorithmia from python code. This library also gets bundled with any Python algorithms in Algorithmia.',
     url='http://github.com/algorithmiaio/algorithmia-python',


### PR DESCRIPTION
Some data connectors return timestamps with fractional seconds, thus we've updated the format used to parse these timestamps, accordingly.