### PR TITLE
Update setuptools before CI runs

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         python setup.py install
     - name: Test with pytest
       env:


### PR DESCRIPTION
There was an error running CI on some older python versions, now it passes. Updating setuptools was enough to fix it. Thanks again StackOverflow