### PR TITLE
Add request timeout value for all request methods

### DIFF
--- a/Algorithmia/CLI.py
+++ b/Algorithmia/CLI.py
@@ -1,9 +1,9 @@
 import Algorithmia
 import os
 from Algorithmia.algo_response import AlgoResponse
+from Algorithmia.client import REQUEST_TIMEOUT
 import json, re, requests, six
 import toml
-
 
 class CLI():
     def __init__(self):
@@ -102,7 +102,7 @@ class CLI():
 
         if(content != None):
             result = AlgoResponse.create_algo_response(requests.post(url, data=algo_input,
-                    headers={'Authorization':key,'Content-Type':content}, params= algo.query_parameters).json())
+                    headers={'Authorization':key,'Content-Type':content}, params= algo.query_parameters, timeout=REQUEST_TIMEOUT).json())
 
         if(result != None):
             output = result.result

--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -9,6 +9,8 @@ from algorithmia_api_client import Configuration, DefaultApi, ApiClient
 import json, re, requests, six
 import os
 
+REQUEST_TIMEOUT = 5
+
 class Client(object):
     'Algorithmia Common Library'
 
@@ -40,6 +42,8 @@ class Client(object):
         if dataUrl.startswith('file://'): return LocalDataDirectory(self, dataUrl)
         else: return DataDirectory(self, dataUrl)
 
+    requests.post(url, data=algo_input,
+                    headers={'Authorization':key,'Content-Type':content}, params= algo.query_parameters, timeout=REQUEST_TIMEOUT).json()
     # Used internally to post json to the api and parse json response
     def postJsonHelper(self, url, input_object, parse_response_as_json=True, **query_parameters):
         headers = {}
@@ -60,7 +64,7 @@ class Client(object):
             input_json = json.dumps(input_object).encode('utf-8')
             headers['Content-Type'] = 'application/json'
 
-        response = requests.post(self.apiAddress + url, data=input_json, headers=headers, params=query_parameters)
+        response = requests.post(self.apiAddress + url, data=input_json, headers=headers, params=query_parameters, timeout=REQUEST_TIMEOUT)
 
         if parse_response_as_json:
             return response.json()
@@ -71,27 +75,27 @@ class Client(object):
         headers = {}
         if self.apiKey is not None:
             headers['Authorization'] = self.apiKey
-        return requests.get(self.apiAddress + url, headers=headers, params=query_parameters)
+        return requests.get(self.apiAddress + url, headers=headers, params=query_parameters, timeout=REQUEST_TIMEOUT)
 
     def patchHelper(self, url, params):
         headers = {'content-type': 'application/json'}
         if self.apiKey is not None:
             headers['Authorization'] = self.apiKey
-        return requests.patch(self.apiAddress + url, headers=headers, data=json.dumps(params))
+        return requests.patch(self.apiAddress + url, headers=headers, data=json.dumps(params), timeout=REQUEST_TIMEOUT)
 
     # Used internally to get http head result
     def headHelper(self, url):
         headers = {}
         if self.apiKey is not None:
             headers['Authorization'] = self.apiKey
-        return requests.head(self.apiAddress + url, headers=headers)
+        return requests.head(self.apiAddress + url, headers=headers, timeout=REQUEST_TIMEOUT)
 
     # Used internally to http put a file
     def putHelper(self, url, data):
         headers = {}
         if self.apiKey is not None:
             headers['Authorization'] = self.apiKey
-        response = requests.put(self.apiAddress + url, data=data, headers=headers)
+        response = requests.put(self.apiAddress + url, data=data, headers=headers, timeout=REQUEST_TIMEOUT)
         return response.json()
 
     # Used internally to http delete a file
@@ -99,5 +103,5 @@ class Client(object):
         headers = {}
         if self.apiKey is not None:
             headers['Authorization'] = self.apiKey
-        response = requests.delete(self.apiAddress + url, headers=headers)
+        response = requests.delete(self.apiAddress + url, headers=headers, timeout=REQUEST_TIMEOUT)
         return response.json()

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     'console_scripts': ['algo = Algorithmia.__main__:main']
     },
     install_requires=[
-        'requests',
+        'requests>=2.4.0',
         'six',
         'enum34',
         'toml',


### PR DESCRIPTION
This is a sensible thing, but specifically recommended by requests

https://2.python-requests.org/en/master/user/quickstart/#timeouts

> Nearly all production code should use this parameter in nearly all requests.
> Failure to do so can cause your program to hang indefinitely

this was introduced in requests 2.4.0 so i've added a version constraint
to setup.py to support this.

See https://requests.readthedocs.io/en/latest/community/updates/#id55

I'm using a constant in `Algorithmia/client` to do this. I want to make it clear that it's static config at the moment so as to keep a single source of truth.