### PR TITLE
More robust error handling

### DIFF
--- a/Algorithmia/datafile.py
+++ b/Algorithmia/datafile.py
@@ -92,7 +92,7 @@ class DataFile(DataObject):
         if isinstance(data, six.binary_type):
             result = self.client.putHelper(self.url, data)
             if 'error' in result:
-                raise DataApiError(result['error']['message'])
+                raiseApiError(result)
             else:
                 return self
         else:
@@ -103,7 +103,7 @@ class DataFile(DataObject):
         jsonElement = json.dumps(data)
         result = self.client.putHelper(self.url, jsonElement)
         if 'error' in result:
-            raise DataApiError(result['error']['message'])
+            raiseApiError(result)
         else:
             return self
 
@@ -112,7 +112,7 @@ class DataFile(DataObject):
         with open(path, 'rb') as f:
             result = self.client.putHelper(self.url, f)
             if 'error' in result:
-                raise DataApiError(result['error']['message'])
+                raiseApiError(result)
             else:
                 return self
 
@@ -120,7 +120,7 @@ class DataFile(DataObject):
         # Delete from data api
         result = self.client.deleteHelper(self.url)
         if 'error' in result:
-            raise DataApiError(result['error']['message'])
+            raiseApiError(result)
         else:
             return True
 
@@ -186,19 +186,24 @@ class LocalDataFile():
         # Post to data api
         jsonElement = json.dumps(data)
         result = localPutHelper(self.path, jsonElement)
-        if 'error' in result: raise DataApiError(result['error']['message'])
-        else: return self
+        if 'error' in result:
+            raiseApiError(result)
+        else:
+            return self
 
     def putFile(self, path):
         result = localPutHelper(path, self.path)
-        if 'error' in result: raise DataApiError(result['error']['message'])
-        else: return self
+        if 'error' in result:
+            raiseApiError(result)
+        else:
+            return self
 
     def delete(self):
         try:
             os.remove(self.path)
             return True
-        except: raise DataApiError('Failed to delete local file ' + self.path)
+        except:
+            raise DataApiError('Failed to delete local file ' + self.path)
 
 def localPutHelper(path, contents):
     try:
@@ -206,3 +211,10 @@ def localPutHelper(path, contents):
             f.write(contents)
             return dict(status='success')
     except Exception as e: return dict(error=str(e))
+
+def raiseApiError(result):
+    if 'error' in result:
+        if 'message' in result['error']:
+            raise DataApiError(result['error']['message'])
+        else:
+            raise DataApiError(result['error'])


### PR DESCRIPTION
This should help in the case where the server returns a malformed error response where instead of result.error.message, the server returns result.error as as a string, which caused the error handling to blow up.