### PR TITLE
Updating README to pip3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ For API documentation, see the [PythonDocs](https://algorithmia.com/docs/lang/py
 ## Install from PyPi
 
 The official Algorithmia python client is [available on PyPi](https://pypi.python.org/pypi/algorithmia).
-Install it with pip:
+Install it with pip3:
 
 ```bash
-pip install algorithmia
+pip3 install algorithmia
 ```
 
 ## Install from source


### PR DESCRIPTION
The README was using pip instead of pip3, pip its having multiple issues right now due to the fact that Python 2 its being completely deprecated, so now pip3 its the one that works fine.