### PR TITLE
Adding numpy serialization/deserialization automation

### DIFF
--- a/Algorithmia/datafile.py
+++ b/Algorithmia/datafile.py
@@ -6,6 +6,7 @@ import six
 import tempfile
 from datetime import datetime
 import os.path
+import pkgutil
 
 from Algorithmia.util import getParentAndBase
 from Algorithmia.data import DataObject, DataObjectType
@@ -70,6 +71,18 @@ class DataFile(DataObject):
         # Make HTTP get request
         return self.client.getHelper(self.url).json()
 
+    def getNumpy(self):
+        exists, error = self.existsWithError()
+        if not exists:
+            raise DataApiError('unable to get file {} - {}'.format(self.path, error))
+        np_loader = pkgutil.find_loader('numpy')
+        if np_loader is not None:
+            import numpy as np
+            payload = self.client.getHelper(self.url).json()
+            return np.array(payload)
+        else:
+            raise DataApiError("Attempted to .getNumpy() file without numpy available, please install numpy.")
+
     def exists(self):
         # In order to not break backward compatability keeping this method to only return
         # a boolean
@@ -78,9 +91,10 @@ class DataFile(DataObject):
 
     def existsWithError(self):
         response = self.client.headHelper(self.url)
-        error = None
         if 'X-Error-Message' in response.headers:
             error = response.headers['X-Error-Message']
+        else:
+            error = response.text
         return (response.status_code == 200, error)
 
     def put(self, data):
@@ -115,6 +129,16 @@ class DataFile(DataObject):
                 raise raiseDataApiError(result)
             else:
                 return self
+    def putNumpy(self, array):
+        # Post numpy array as json payload
+        np_loader = pkgutil.find_loader('numpy')
+        if np_loader is not None:
+            import numpy as np
+            encoded_array = array.tolist()
+            self.putJson(encoded_array)
+            return self
+        else:
+            raise DataApiError("Attempted to .getNumpy() file without numpy available, please install numpy.")
 
     def delete(self):
         # Delete from data api

--- a/Algorithmia/datafile.py
+++ b/Algorithmia/datafile.py
@@ -138,7 +138,7 @@ class DataFile(DataObject):
             self.putJson(encoded_array)
             return self
         else:
-            raise DataApiError("Attempted to .getNumpy() file without numpy available, please install numpy.")
+            raise DataApiError("Attempted to .putNumpy() a file without numpy available, please install numpy.")
 
     def delete(self):
         # Delete from data api

--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ $ algo run kenny/factor -d 17 --profile second_user
 
 # Running tests
 
+Make sure you have `numpy` installed before running `datafile_test.py`
 ```bash
 export ALGORITHMIA_API_KEY={{Your API key here}}
 cd Test

--- a/Test/datafile_test.py
+++ b/Test/datafile_test.py
@@ -5,13 +5,15 @@ import sys
 sys.path = ['../'] + sys.path
 
 import unittest, os, uuid
-
+import numpy as np
 import Algorithmia
 from Algorithmia.datafile import DataFile, LocalDataFile
 
 class DataFileTest(unittest.TestCase):
     def setUp(self):
         self.client = Algorithmia.client()
+        if not self.client.dir("data://.my/empty").exists():
+            self.client.dir("data://.my/empty").create()
 
     def test_get_nonexistant(self):
         df = self.client.file('data://.my/nonexistant/nonreal')
@@ -42,11 +44,24 @@ class DataFileTest(unittest.TestCase):
         except Exception as e:
             self.fail("set_attributes failed with exception: " + str(e))
 
-    def test_putJson(self):
+    def test_putJson_getJson(self):
         file = '.my/empty/test.json'
         df = DataFile(self.client,'data://'+file)
-        response = df.putJson({"hello":"world"})
+        payload = {"hello":"world"}
+        response = df.putJson(payload)
         self.assertEqual(response.path,file)
+        result = self.client.file(file).getJson()
+        self.assertEqual(str(result), str(payload))
+
+    def test_putNumpy_getNumpy(self):
+        file = ".my/empty/numpy.json"
+        df = DataFile(self.client, 'data://' + file)
+        arr = np.array([0, 0, 0, 0], dtype=np.int64)
+        response = df.putNumpy(arr)
+        self.assertEqual(response.path, file)
+        result = self.client.file(file).getNumpy()
+        self.assertEqual(str(arr), str(result))
+
         
 class LocalFileTest(unittest.TestCase):
     DUMMY_TEXT = 'this file gets populated during testing'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ toml
 argparse
 algorithmia-api-client>=1.3,<1.4
 algorithmia-adk>=1.0,<1.1
+numpy>=1.20,<1.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ toml
 argparse
 algorithmia-api-client>=1.3,<1.4
 algorithmia-adk>=1.0,<1.1
-numpy>=1.20,<1.21
+numpy<2


### PR DESCRIPTION
This PR adds the following:
to the `client.file()` endpoint:
- `.getNumpy()` this gets a file as a serialized numpy array
- `.putNumpy()` this takes a regular numpy array and serializes it into a json compatible format automatically
- if numpy is not installed, the user will get an error stating that they need to have numpy installed.

This also adds tests for both `.getNumpy` and ``.putNumpy()` endpoints
This can be tested by running `python3 datafile_test.py`