### PR TITLE
error handling fix

### DIFF
--- a/Algorithmia/algo_response.py
+++ b/Algorithmia/algo_response.py
@@ -23,10 +23,10 @@ class AlgoResponse(object):
         if 'metadata' in responseJson:
             metadata = Metadata(responseJson['metadata'])
             # Success, check content_type
-            if responseJson['metadata']['content_type'] == 'binary':
+            if metadata.content_type == 'binary':
                 # Decode Base64 encoded binary file
                 return AlgoResponse(base64.b64decode(responseJson['result']), metadata)
-            elif responseJson['metadata']['content_type'] == 'void':
+            elif metadata.content_type == 'void':
                 return AlgoResponse(None, metadata)
             else:
                 return AlgoResponse(responseJson['result'], metadata)

--- a/Algorithmia/algo_response.py
+++ b/Algorithmia/algo_response.py
@@ -20,10 +20,7 @@ class AlgoResponse(object):
     @staticmethod
     def create_algo_response(responseJson):
         # Parse response JSON
-        if 'error' in responseJson:
-            # Failure
-            raise raiseAlgoApiError(responseJson)
-        else:
+        if 'metadata' in responseJson:
             metadata = Metadata(responseJson['metadata'])
             # Success, check content_type
             if responseJson['metadata']['content_type'] == 'binary':
@@ -33,6 +30,9 @@ class AlgoResponse(object):
                 return AlgoResponse(None, metadata)
             else:
                 return AlgoResponse(responseJson['result'], metadata)
+        else:
+            # Failure
+            raise raiseAlgoApiError(responseJson)
 
 class Metadata(object):
     def __init__(self, metadata):

--- a/Algorithmia/algo_response.py
+++ b/Algorithmia/algo_response.py
@@ -20,7 +20,7 @@ class AlgoResponse(object):
     @staticmethod
     def create_algo_response(responseJson):
         # Parse response JSON
-        if 'metadata' in responseJson:
+        if 'result' in responseJson:
             metadata = Metadata(responseJson['metadata'])
             # Success, check content_type
             if metadata.content_type == 'binary':

--- a/Algorithmia/algo_response.py
+++ b/Algorithmia/algo_response.py
@@ -36,8 +36,8 @@ class AlgoResponse(object):
 
 class Metadata(object):
     def __init__(self, metadata):
-        self.content_type = metadata['content_type']
-        self.duration = metadata['duration']
+        self.content_type = metadata.get('content_type', None)
+        self.duration = metadata.get('duration', None)
         self.stdout = None
         if 'stdout' in metadata:
             self.stdout = metadata['stdout']


### PR DESCRIPTION
This corrects a failure case where if an HTTP response failure (5xx) is raised; the previous behavior would respond with a JSON parsing issue. Modifications have been made to ensure that exceptions/errors thrown from non Algorithmia API derived services will be raised without JSON parsing.