### PR TITLE
Added support for exception handling testing

### DIFF
--- a/Algorithmia/__init__.py
+++ b/Algorithmia/__init__.py
@@ -23,8 +23,8 @@ def file(dataUrl):
 def dir(dataUrl):
     return getDefaultClient().dir(dataUrl)
 
-def client(api_key=None, api_address=None, ca_cert=None):
-    return Client(api_key, api_address, ca_cert)
+def client(api_key=None, api_address=None, ca_cert=None, dummy=False):
+    return Client(api_key, api_address, ca_cert, dummy)
 
 def handler(apply_func, load_func=lambda: None):
     return Handler(apply_func, load_func)

--- a/Algorithmia/algo_response.py
+++ b/Algorithmia/algo_response.py
@@ -18,21 +18,21 @@ class AlgoResponse(object):
             return self.__unicode__().encode('utf-8')
 
     @staticmethod
-    def create_algo_response(responseJson):
-        # Parse response JSON
-        if 'error' in responseJson:
+    def create_algo_response(response):
+        # Parse response JSON, if it's indeed JSON
+        if 'error' in response or 'metadata' not in response:
             # Failure
-            raise raiseAlgoApiError(responseJson)
+            raise raiseAlgoApiError(response)
         else:
-            metadata = Metadata(responseJson['metadata'])
+            metadata = Metadata(response['metadata'])
             # Success, check content_type
-            if responseJson['metadata']['content_type'] == 'binary':
+            if response['metadata']['content_type'] == 'binary':
                 # Decode Base64 encoded binary file
-                return AlgoResponse(base64.b64decode(responseJson['result']), metadata)
-            elif responseJson['metadata']['content_type'] == 'void':
+                return AlgoResponse(base64.b64decode(response['result']), metadata)
+            elif response['metadata']['content_type'] == 'void':
                 return AlgoResponse(None, metadata)
             else:
-                return AlgoResponse(responseJson['result'], metadata)
+                return AlgoResponse(response['result'], metadata)
 
 class Metadata(object):
     def __init__(self, metadata):

--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -28,7 +28,7 @@ class Client(object):
         self.requestSession = requests.Session()
         if dummy:
             self.apiKey = "API_KEY"
-            self.apiaddress = "localhost"
+            self.apiAddress = "http://localhost:8080"
         else:
             if apiKey is None and 'ALGORITHMIA_API_KEY' in os.environ:
                 apiKey = os.environ['ALGORITHMIA_API_KEY']
@@ -145,7 +145,7 @@ class Client(object):
 
         response = self.requestSession.post(self.apiAddress + url, data=input_json, headers=headers, params=query_parameters)
 
-        if parse_response_as_json:
+        if parse_response_as_json and response.status_code == 200:
             return response.json()
         return response
 

--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -23,33 +23,37 @@ class Client(object):
     requestSession = None
 
 
-    def __init__(self, apiKey = None, apiAddress = None, caCert = None):
+    def __init__(self, apiKey = None, apiAddress = None, caCert = None, dummy = False):
         # Override apiKey with environment variable
         self.requestSession = requests.Session()
-        if apiKey is None and 'ALGORITHMIA_API_KEY' in os.environ:
-            apiKey = os.environ['ALGORITHMIA_API_KEY']
-        self.apiKey = apiKey
-        if apiAddress is not None:
-            self.apiAddress = apiAddress
+        if dummy:
+            self.apiKey = "API_KEY"
+            self.apiaddress = "localhost"
         else:
-            self.apiAddress = Algorithmia.getApiAddress()
-        if caCert is None and 'REQUESTS_CA_BUNDLE' in os.environ:
-            caCert = os.environ.get('REQUESTS_CA_BUNDLE')
-            self.catCerts(caCert)
-            self.requestSession.verify = self.ca_cert
-        elif caCert is not None and 'REQUESTS_CA_BUNDLE' not in os.environ:
-            self.catCerts(caCert)
-            self.requestSession.verify = self.ca_cert
-        elif caCert is not None and 'REQUESTS_CA_BUNDLE' in os.environ:
-            #if both are available, use the one supplied in the constructor. I assume that a user supplying a cert in initialization wants to use that one. 
-            self.catCerts(caCert)
-            self.requestSession.verify = self.ca_cert
+            if apiKey is None and 'ALGORITHMIA_API_KEY' in os.environ:
+                apiKey = os.environ['ALGORITHMIA_API_KEY']
+            self.apiKey = apiKey
+            if apiAddress is not None:
+                self.apiAddress = apiAddress
+            else:
+                self.apiAddress = Algorithmia.getApiAddress()
+            if caCert is None and 'REQUESTS_CA_BUNDLE' in os.environ:
+                caCert = os.environ.get('REQUESTS_CA_BUNDLE')
+                self.catCerts(caCert)
+                self.requestSession.verify = self.ca_cert
+            elif caCert is not None and 'REQUESTS_CA_BUNDLE' not in os.environ:
+                self.catCerts(caCert)
+                self.requestSession.verify = self.ca_cert
+            elif caCert is not None and 'REQUESTS_CA_BUNDLE' in os.environ:
+                #if both are available, use the one supplied in the constructor. I assume that a user supplying a cert in initialization wants to use that one.
+                self.catCerts(caCert)
+                self.requestSession.verify = self.ca_cert
 
 
-        config = Configuration()
-        config.api_key['Authorization'] = self.apiKey
-        config.host = "{}/v1".format(self.apiAddress)
-        self.manageApi = DefaultApi(ApiClient(config))
+            config = Configuration()
+            config.api_key['Authorization'] = self.apiKey
+            config.host = "{}/v1".format(self.apiAddress)
+            self.manageApi = DefaultApi(ApiClient(config))
         
     def algo(self, algoRef):
         return Algorithm(self, algoRef)

--- a/Algorithmia/local_api.py
+++ b/Algorithmia/local_api.py
@@ -1,5 +1,5 @@
 import importlib
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from fastapi.responses import HTMLResponse
 
 app = FastAPI()
@@ -12,8 +12,14 @@ async def root():
         """
     )
 
+@app.post("/v1/{username}/{algoname}/{version}")
+async def throw_error(username, algoname, version):
+    return Response("Internal Server Error", status_code=500)
+
+
 def create_endpoint(algoname):
     module = importlib.import_module(algoname)
     @app.get("/invocations")
     def invocations(data):
          return module.apply(data)
+

--- a/Test/algo_failure_test.py
+++ b/Test/algo_failure_test.py
@@ -1,0 +1,37 @@
+import sys
+import os
+from Algorithmia.errors import AlgorithmException
+import Algorithmia.local_api as local_api
+from multiprocessing import Process
+from requests import HTTPError
+# look in ../ BEFORE trying to import Algorithmia.  If you append to the
+# you will load the version installed on the computer.
+sys.path = ['../'] + sys.path
+
+import unittest
+import Algorithmia
+import uvicorn
+import time
+from requests import Response
+
+def start_webserver():
+    uvicorn.run(local_api.app, host="127.0.0.1", port=8080, log_level="debug")
+
+class AlgoTest(unittest.TestCase):
+    error_500 = Response()
+    error_500.status_code = 500
+
+    def setUp(self):
+        self.client = Algorithmia.client(dummy=True)
+        self.uvi_p = Process(target=start_webserver)
+        self.uvi_p.start()
+        time.sleep(1)
+    def tearDown(self):
+        self.uvi_p.terminate()
+    def test_throw_500_error_HTTP_response_on_algo_request(self):
+        try:
+            result = self.client.algo('util/Echo').pipe(bytearray('foo','utf-8'))
+        except Exception as e:
+            result = e
+            pass
+        self.assertEqual(str(self.error_500), str(result))

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ algorithmia-api-client>=1.3,<1.4
 algorithmia-adk>=1.0.2,<1.1
 numpy<2
 uvicorn==0.14.0
+fastapi==0.65.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ argparse
 algorithmia-api-client>=1.3,<1.4
 algorithmia-adk>=1.0.2,<1.1
 numpy<2
+uvicorn==0.14.0


### PR DESCRIPTION
These changes utilized the fastAPI service that @danielfrg has added to our client enabling local development, to also allow us to test the algorithm response handling interface in the face of server failures such as 5xx exceptions.

The modifications themselves are a WIP, however the interface itself has been tested and proven to be reliable, more work may be done in the future to make it more idiomatically fastAPI.