### PR TITLE
ALGO fix api client version conflict issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'enum-compat',
         'toml',
         'argparse',
-        'algorithmia-api-client>=1.3,<2',
+        'algorithmia-api-client>=1.3,<1.4',
         'algorithmia-adk>=1.0.2,<1.1'
     ],
     include_package_data=True,


### PR DESCRIPTION
version 1.5.0 is broken but was undetected due to requirements.txt / setup.py divergence, this reverts that change. Once merged will ship as a new tag.