### PR TITLE
Change printed header for listing languages

### DIFF
--- a/Algorithmia/__main__.py
+++ b/Algorithmia/__main__.py
@@ -202,15 +202,15 @@ def main():
 
     elif args.cmd == 'languages':
         response = CLI().list_languages(client)
-        print("{:<25} {:<35}".format('Name','Display Name'))
+        print("{:<25} {:<35}".format('Name', 'Display Name'))
         for lang in response:
-            print("{:<25} {:<35}".format(lang['name'],lang['display_name']))
+            print("{:<25} {:<35}".format(lang['name'], lang['display_name']))
 
     elif args.cmd == 'template':
         CLI().get_template(args.envid,args.dest,client)
 
     elif args.cmd == 'environment':
-        response = CLI().get_environment_by_language(args.language,client)
+        response = CLI().get_environment_by_language(args.language, client)
         print(response)
 
     elif args.cmd == 'builds':

--- a/Algorithmia/__main__.py
+++ b/Algorithmia/__main__.py
@@ -202,7 +202,7 @@ def main():
         
     elif args.cmd == 'languages':
         response = CLI().list_languages(client)
-        print("{:<25} {:<35}".format('Name','Description'))
+        print("{:<25} {:<35}".format('Name','Display Name'))
         for lang in response:
             print("{:<25} {:<35}".format(lang['name'],lang['display_name']))
 

--- a/Algorithmia/__main__.py
+++ b/Algorithmia/__main__.py
@@ -199,7 +199,7 @@ def main():
 
     elif args.cmd == 'cat':
         print(CLI().cat(args.path, client))
-        
+
     elif args.cmd == 'languages':
         response = CLI().list_languages(client)
         print("{:<25} {:<35}".format('Name','Display Name'))


### PR DESCRIPTION
Small change to align printed output with name of properties in payload. The column is listing the `display_name` property, so let's just call it that. Also, `description` is the name of a field in the payload when you list environments, so I think it could be confusing here.