### PR TITLE
Enabling the ability to disable SSL certificate requirements for mgmt API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 #Eclipse
 .project
 
+TestFiles
+test.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -35,21 +35,25 @@ class Client(object):
         else:
             self.apiAddress = Algorithmia.getApiAddress()
         if caCert == False:
+            print("cacert is false")
             self.requestSession.verify = False
-        elif caCert is None and 'REQUESTS_CA_BUNDLE' in os.environ:
-            caCert = os.environ.get('REQUESTS_CA_BUNDLE')
-            self.catCerts(caCert)
-            self.requestSession.verify = self.ca_cert
-        elif caCert is not None and 'REQUESTS_CA_BUNDLE' not in os.environ:
-            self.catCerts(caCert)
-            self.requestSession.verify = self.ca_cert
-        elif caCert is not None and 'REQUESTS_CA_BUNDLE' in os.environ:
-            #if both are available, use the one supplied in the constructor. I assume that a user supplying a cert in initialization wants to use that one.
-            self.catCerts(caCert)
-            self.requestSession.verify = self.ca_cert
+            config = Configuration(use_ssl=False)
+        else:
+            print("cacert is not false")
+            config = Configuration()
+            if caCert is None and 'REQUESTS_CA_BUNDLE' in os.environ:
+                caCert = os.environ.get('REQUESTS_CA_BUNDLE')
+                self.catCerts(caCert)
+                self.requestSession.verify = self.ca_cert
+            elif caCert is not None and 'REQUESTS_CA_BUNDLE' not in os.environ:
+                self.catCerts(caCert)
+                self.requestSession.verify = self.ca_cert
+            elif caCert is not None and 'REQUESTS_CA_BUNDLE' in os.environ:
+                #if both are available, use the one supplied in the constructor. I assume that a user supplying a cert in initialization wants to use that one.
+                self.catCerts(caCert)
+                self.requestSession.verify = self.ca_cert
 
 
-        config = Configuration()
         config.api_key['Authorization'] = self.apiKey
         config.host = "{}/v1".format(self.apiAddress)
         self.manageApi = DefaultApi(ApiClient(config))

--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -35,11 +35,9 @@ class Client(object):
         else:
             self.apiAddress = Algorithmia.getApiAddress()
         if caCert == False:
-            print("cacert is false")
             self.requestSession.verify = False
             config = Configuration(use_ssl=False)
         else:
-            print("cacert is not false")
             config = Configuration()
             if caCert is None and 'REQUESTS_CA_BUNDLE' in os.environ:
                 caCert = os.environ.get('REQUESTS_CA_BUNDLE')

--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -38,7 +38,7 @@ class Client(object):
         if caCert == False:
             self.requestSession.verify = False
             config = Configuration(use_ssl=False)
-        if caCert is None and 'REQUESTS_CA_BUNDLE' in os.environ:
+        elif caCert is None and 'REQUESTS_CA_BUNDLE' in os.environ:
             caCert = os.environ.get('REQUESTS_CA_BUNDLE')
             self.catCerts(caCert)
             self.requestSession.verify = self.ca_cert

--- a/Test/client_test.py
+++ b/Test/client_test.py
@@ -35,6 +35,7 @@ class client_test(unittest.TestCase):
         response = self.c.create_org({"org_name": self.orgname, "org_label": "some label", "org_contact_name": "Some owner", "org_email": self.orgname+"@algo.com","type_id":"basic"})
         self.assertEqual(self.orgname,response['org_name'])
 
+
     def test_get_org(self):
         response = self.c.get_org("a_myOrg84")
         self.assertEqual("a_myOrg84",response['org_name'])
@@ -52,6 +53,15 @@ class client_test(unittest.TestCase):
         user = os.environ.get('ALGO_USER_NAME')
         algo = "Echo"
         result = client.algo(user+'/'+algo).build_logs()
+        if "error" in result:
+            print(result)
+        self.assertTrue("error" not in result)
+
+    def test_get_build_logs_no_ssl(self):
+        client = Algorithmia.client(api_key=os.environ.get('ALGORITHMIA_API_KEY'), ca_cert=False)
+        user = os.environ.get('ALGO_USER_NAME')
+        algo = "Echo"
+        result = client.algo(user + '/' + algo).build_logs()
         if "error" in result:
             print(result)
         self.assertTrue("error" not in result)
@@ -93,6 +103,7 @@ class client_test(unittest.TestCase):
         if("error" in response):
             print(response)
         self.assertTrue(response is not None and language_found)
+
 
 
     def test_invite_to_org(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ six
 enum-compat
 toml
 argparse
-algorithmia-api-client>=1.3,<1.6
+algorithmia-api-client==1.5.1
 algorithmia-adk>=1.0.2,<1.1
 numpy<2
 uvicorn==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ six
 enum-compat
 toml
 argparse
-algorithmia-api-client>=1.3,<1.4
+algorithmia-api-client>=1.3,<1.6
 algorithmia-adk>=1.0.2,<1.1
 numpy<2
 uvicorn==0.14.0

--- a/requirements27.txt
+++ b/requirements27.txt
@@ -3,6 +3,6 @@ six
 enum-compat
 toml
 argparse
-algorithmia-api-client>=1.3,<1.4
+algorithmia-api-client==1.5.1
 algorithmia-adk>=1.0.2,<1.1
 numpy<2

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'enum-compat',
         'toml',
         'argparse',
-        'algorithmia-api-client>=1.3,<1.6',
+        'algorithmia-api-client==1.5.1',
         'algorithmia-adk>=1.0.2,<1.1'
     ],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'enum-compat',
         'toml',
         'argparse',
-        'algorithmia-api-client>=1.3,<1.4',
+        'algorithmia-api-client>=1.3,<1.6',
         'algorithmia-adk>=1.0.2,<1.1'
     ],
     include_package_data=True,


### PR DESCRIPTION
pass `ca_cert=False` to the `Algorithmia.client()` initializer with at least `1.5.1` of the Algorithmia API Client installed, and it should now enable not only algorithm requests without SSL verification, but algorithm creation and advanced management workflows such as `algo.create()`.