### PR TITLE
supporting custom CA cert files

### DIFF
--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -45,10 +45,12 @@ class Client(object):
         elif caCert is not None and 'REQUESTS_CA_BUNDLE' not in os.environ:
             self.catCerts(caCert)
             self.requestSession.verify = self.ca_cert
+            config = Configuration(cert_file=self.ca_cert)
         elif caCert is not None and 'REQUESTS_CA_BUNDLE' in os.environ:
             #if both are available, use the one supplied in the constructor. I assume that a user supplying a cert in initialization wants to use that one.
             self.catCerts(caCert)
             self.requestSession.verify = self.ca_cert
+            config = Configuration(cert_file=self.ca_cert)
 
         if not config:
             config = Configuration()

--- a/Test/client_test.py
+++ b/Test/client_test.py
@@ -66,6 +66,20 @@ class client_test(unittest.TestCase):
             print(result)
         self.assertTrue("error" not in result)
 
+    def test_get_build_logs_customCert(self):
+        with open("./test.pem",'w'):
+            client = Algorithmia.client(api_key=os.environ.get('ALGORITHMIA_API_KEY'), ca_cert="./test.pem")
+            user = os.environ.get('ALGO_USER_NAME')
+            algo = "Echo"
+            result = client.algo(user + '/' + algo).build_logs()
+            if "error" in result:
+                print(result)
+            self.assertTrue("error" not in result)
+        try:
+            os.remove("./test.pem")
+        except OSError as e:
+            print(e)
+
 
     def test_edit_org(self):
         orgname="a_myOrg84"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ six
 enum-compat
 toml
 argparse
-algorithmia-api-client==1.5.1
+algorithmia-api-client==1.5.2
 algorithmia-adk>=1.0.2,<1.1
 numpy<2
 uvicorn==0.14.0

--- a/requirements27.txt
+++ b/requirements27.txt
@@ -3,6 +3,6 @@ six
 enum-compat
 toml
 argparse
-algorithmia-api-client==1.5.1
+algorithmia-api-client==1.5.2
 algorithmia-adk>=1.0.2,<1.1
 numpy<2

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'enum-compat',
         'toml',
         'argparse',
-        'algorithmia-api-client==1.5.1',
+        'algorithmia-api-client==1.5.2',
         'algorithmia-adk>=1.0.2,<1.1'
     ],
     include_package_data=True,


### PR DESCRIPTION
Added a path in the api client to enable custom ca cert files being used by the generated API client; this PR permits that functionality with the python client.