### PR TITLE
Makes DataFiles FileIO compatible

### DIFF
--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -63,19 +63,15 @@ class Client(object):
         username = next(self.dir("").list()).path
         return username
 
-    def file(self, dataUrl, legacy=True, cleanup=False):
+    def file(self, dataUrl, cleanup=False):
         if dataUrl.startswith('file://'):
             return LocalDataFile(self, dataUrl)
-        elif legacy:
-            return DataFile(self, dataUrl)
         else:
             return AdvancedDatafile(self, dataUrl, cleanup)
 
-    def dir(self, dataUrl, legacy=True):
+    def dir(self, dataUrl):
         if dataUrl.startswith('file://'):
             return LocalDataDirectory(self, dataUrl)
-        elif legacy:
-            return DataDirectory(self, dataUrl)
         else:
             return AdvancedDataDirectory(self, dataUrl)
 

--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -3,8 +3,8 @@
 import Algorithmia
 from Algorithmia.insights import Insights
 from Algorithmia.algorithm import Algorithm
-from Algorithmia.datafile import DataFile, LocalDataFile
-from Algorithmia.datadirectory import DataDirectory, LocalDataDirectory
+from Algorithmia.datafile import DataFile, LocalDataFile, AdvancedDatafile
+from Algorithmia.datadirectory import DataDirectory, LocalDataDirectory, AdvancedDataDirectory
 from algorithmia_api_client import Configuration, DefaultApi, ApiClient
 
 from tempfile import mkstemp
@@ -63,13 +63,21 @@ class Client(object):
         username = next(self.dir("").list()).path
         return username
 
-    def file(self, dataUrl):
-        if dataUrl.startswith('file://'): return LocalDataFile(self, dataUrl)
-        else: return DataFile(self, dataUrl)
+    def file(self, dataUrl, advanced=False):
+        if dataUrl.startswith('file://'):
+            return LocalDataFile(self, dataUrl)
+        elif advanced:
+            return AdvancedDatafile(self, dataUrl)
+        else:
+            return DataFile(self, dataUrl)
 
-    def dir(self, dataUrl):
-        if dataUrl.startswith('file://'): return LocalDataDirectory(self, dataUrl)
-        else: return DataDirectory(self, dataUrl)
+    def dir(self, dataUrl, advanced=False):
+        if dataUrl.startswith('file://'):
+            return LocalDataDirectory(self, dataUrl)
+        elif advanced:
+            return AdvancedDataDirectory(self, dataUrl)
+        else:
+            return DataDirectory(self, dataUrl)
 
     def create_user(self, requestString):
         url = "/v1/users" 

--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -63,21 +63,21 @@ class Client(object):
         username = next(self.dir("").list()).path
         return username
 
-    def file(self, dataUrl, advanced=False):
+    def file(self, dataUrl, legacy=True, cleanup=False):
         if dataUrl.startswith('file://'):
             return LocalDataFile(self, dataUrl)
-        elif advanced:
-            return AdvancedDatafile(self, dataUrl)
-        else:
+        elif legacy:
             return DataFile(self, dataUrl)
+        else:
+            return AdvancedDatafile(self, dataUrl, cleanup)
 
-    def dir(self, dataUrl, advanced=False):
+    def dir(self, dataUrl, legacy=True):
         if dataUrl.startswith('file://'):
             return LocalDataDirectory(self, dataUrl)
-        elif advanced:
-            return AdvancedDataDirectory(self, dataUrl)
-        else:
+        elif legacy:
             return DataDirectory(self, dataUrl)
+        else:
+            return AdvancedDataDirectory(self, dataUrl)
 
     def create_user(self, requestString):
         url = "/v1/users" 

--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -3,7 +3,7 @@
 import Algorithmia
 from Algorithmia.insights import Insights
 from Algorithmia.algorithm import Algorithm
-from Algorithmia.datafile import DataFile, LocalDataFile, AdvancedDatafile
+from Algorithmia.datafile import DataFile, LocalDataFile, AdvancedDataFile
 from Algorithmia.datadirectory import DataDirectory, LocalDataDirectory, AdvancedDataDirectory
 from algorithmia_api_client import Configuration, DefaultApi, ApiClient
 
@@ -67,7 +67,7 @@ class Client(object):
         if dataUrl.startswith('file://'):
             return LocalDataFile(self, dataUrl)
         else:
-            return AdvancedDatafile(self, dataUrl, cleanup)
+            return AdvancedDataFile(self, dataUrl, cleanup)
 
     def dir(self, dataUrl):
         if dataUrl.startswith('file://'):

--- a/Algorithmia/datadirectory.py
+++ b/Algorithmia/datadirectory.py
@@ -7,7 +7,7 @@ import six
 import tempfile
 import Algorithmia
 
-from Algorithmia.datafile import DataFile, AdvancedDatafile, LocalDataFile
+from Algorithmia.datafile import DataFile, AdvancedDataFile, LocalDataFile
 from Algorithmia.data import DataObject, DataObjectType
 from Algorithmia.errors import DataApiError
 from Algorithmia.util import getParentAndBase, pathJoin
@@ -190,4 +190,4 @@ class AdvancedDataDirectory(DataDirectory):
         super(AdvancedDataDirectory, self).__init__(client, dataUrl)
 
     def file(self, name, cleanup=True):
-        return AdvancedDatafile(self.client, pathJoin(self.path, name), cleanup)
+        return AdvancedDataFile(self.client, pathJoin(self.path, name), cleanup)

--- a/Algorithmia/datadirectory.py
+++ b/Algorithmia/datadirectory.py
@@ -5,13 +5,14 @@ import re
 import os
 import six
 import tempfile
-
 import Algorithmia
-from Algorithmia.datafile import DataFile
+
+from Algorithmia.datafile import DataFile, AdvancedDatafile, LocalDataFile
 from Algorithmia.data import DataObject, DataObjectType
 from Algorithmia.errors import DataApiError
 from Algorithmia.util import getParentAndBase, pathJoin
 from Algorithmia.acl import Acl
+
 
 class DataDirectory(DataObject):
     def __init__(self, client, dataUrl):
@@ -41,7 +42,7 @@ class DataDirectory(DataObject):
     def create(self, acl=None):
         '''Creates a directory, optionally include Acl argument to set permissions'''
         parent, name = getParentAndBase(self.path)
-        json = { 'name': name }
+        json = {'name': name}
         if acl is not None:
             json['acl'] = acl.to_api_param()
         response = self.client.postJsonHelper(DataDirectory._getUrl(parent), json, False)
@@ -90,7 +91,7 @@ class DataDirectory(DataObject):
             return None
 
     def update_permissions(self, acl):
-        params = {'acl':acl.to_api_param()}
+        params = {'acl': acl.to_api_param()}
         response = self.client.patchHelper(self.url, params)
         if response.status_code != 200:
             raise DataApiError('Unable to update permissions: ' + response.json()['error']['message'])
@@ -102,7 +103,7 @@ class DataDirectory(DataObject):
         while first or (marker is not None and len(marker) > 0):
             first = False
             url = self.url
-            query_params= {}
+            query_params = {}
             if marker:
                 query_params['marker'] = marker
             response = self.client.getHelper(url, **query_params)
@@ -177,8 +178,16 @@ class LocalDataDirectory():
 
     def dirs(self, content):
         for x in os.listdir(self.path):
-            if os.path.isdir(self.path+'/'+x): yield x
+            if os.path.isdir(self.path + '/' + x): yield x
 
     def files(self, content):
         for x in os.listdir(self.path):
-            if os.path.isfile(self.path+'/'+x): yield x
+            if os.path.isfile(self.path + '/' + x): yield x
+
+
+class AdvancedDataDirectory(DataDirectory):
+    def __init__(self, client, dataUrl):
+        super(AdvancedDataDirectory, self).__init__(client, dataUrl)
+
+    def file(self, name, cleanup=True):
+        return AdvancedDatafile(self.client, pathJoin(self.path, name), cleanup)

--- a/Algorithmia/datadirectory.py
+++ b/Algorithmia/datadirectory.py
@@ -182,7 +182,8 @@ class LocalDataDirectory():
 
     def files(self, content):
         for x in os.listdir(self.path):
-            if os.path.isfile(self.path + '/' + x): yield x
+            if os.path.isfile(self.path + '/' + x):
+                yield x
 
 
 class AdvancedDataDirectory(DataDirectory):

--- a/Algorithmia/datafile.py
+++ b/Algorithmia/datafile.py
@@ -266,20 +266,29 @@ class AdvancedDatafile(DataFile, RawIOBase):
     def read(self, __size=None):
         if not self.local_file:
             self.local_file = self.getFile()
-        output = self.local_file.read(__size)
+        if __size:
+            output = self.local_file.read(__size)
+        else:
+            output = self.local_file.read()
         return output
 
     def readline(self, __size=None):
         if not self.local_file:
             self.local_file = self.getFile()
         with self.local_file as f:
-            output = f.readline(__size)
+            if __size:
+                output = f.readline(__size)
+            else:
+                output = f.readline()
         return output
 
     def readlines(self, __hint=None):
         if not self.local_file:
             self.local_file = self.getFile()
-        output = self.local_file.readlines(__hint)
+        if __hint:
+            output = self.local_file.readlines(__hint)
+        else:
+            output = self.local_file.readlines()
         return output
 
     def tell(self):

--- a/Algorithmia/datafile.py
+++ b/Algorithmia/datafile.py
@@ -249,7 +249,6 @@ class AdvancedDatafile(DataFile, RawIOBase):
         self.local_file = None
 
     def __del__(self):
-        print("destructor called")
         if self.local_file:
             self.local_file.close()
             if self.cleanup:

--- a/Algorithmia/datafile.py
+++ b/Algorithmia/datafile.py
@@ -11,6 +11,7 @@ import pkgutil
 from Algorithmia.util import getParentAndBase
 from Algorithmia.data import DataObject, DataObjectType
 from Algorithmia.errors import DataApiError, raiseDataApiError
+from io import RawIOBase
 
 
 class DataFile(DataObject):
@@ -24,7 +25,7 @@ class DataFile(DataObject):
         self.size = None
 
     def set_attributes(self, attributes):
-        self.last_modified = datetime.strptime(attributes['last_modified'],'%Y-%m-%dT%H:%M:%S.%fZ')
+        self.last_modified = datetime.strptime(attributes['last_modified'], '%Y-%m-%dT%H:%M:%S.%fZ')
         self.size = attributes['size']
 
     # Deprecated:
@@ -33,18 +34,20 @@ class DataFile(DataObject):
 
     # Get file from the data api
     def getFile(self):
-        exists, error = self.existsWithError()
-        if not exists:
-            raise DataApiError('unable to get file {} - {}'.format(self.path, error))
-        # Make HTTP get request
-        response = self.client.getHelper(self.url)
-        with tempfile.NamedTemporaryFile(delete = False) as f:
-            for block in response.iter_content(1024):
-                if not block:
-                    break;
-                f.write(block)
-            f.flush()
-            return open(f.name)
+        if not self.local_file:
+            exists, error = self.existsWithError()
+            if not exists:
+                raise DataApiError('unable to get file {} - {}'.format(self.path, error))
+            # Make HTTP get request
+            response = self.client.getHelper(self.url)
+            with tempfile.NamedTemporaryFile(delete=False) as f:
+                for block in response.iter_content(1024):
+                    if not block:
+                        break
+                    f.write(block)
+                f.flush()
+                self.local_file = open(f.name)
+        return open(self.local_file.name)
 
     def getName(self):
         _, name = getParentAndBase(self.path)
@@ -129,6 +132,7 @@ class DataFile(DataObject):
                 raise raiseDataApiError(result)
             else:
                 return self
+
     def putNumpy(self, array):
         # Post numpy array as json payload
         np_loader = pkgutil.find_loader('numpy')
@@ -148,6 +152,7 @@ class DataFile(DataObject):
         else:
             return True
 
+
 class LocalDataFile():
     def __init__(self, client, filePath):
         self.client = client
@@ -158,7 +163,7 @@ class LocalDataFile():
         self.size = None
 
     def set_attributes(self, attributes):
-        self.last_modified = datetime.strptime(attributes['last_modified'],'%Y-%m-%dT%H:%M:%S.%fZ')
+        self.last_modified = datetime.strptime(attributes['last_modified'], '%Y-%m-%dT%H:%M:%S.%fZ')
         self.size = attributes['size']
 
     # Get file from the data api
@@ -229,9 +234,66 @@ class LocalDataFile():
         except:
             raise DataApiError('Failed to delete local file ' + self.path)
 
+
 def localPutHelper(path, contents):
     try:
         with open(path, 'wb') as f:
             f.write(contents)
             return dict(status='success')
-    except Exception as e: return dict(error=str(e))
+    except Exception as e:
+        return dict(error=str(e))
+
+
+class AdvancedDatafile(DataFile, RawIOBase):
+    def __init__(self, client, dataUrl, cleanup=True):
+        super(AdvancedDatafile, self).__init__(client, dataUrl)
+        self.cleanup = cleanup
+        self.local_file = None
+
+    def __del__(self):
+        print("destructor called")
+        if self.local_file:
+            self.local_file.close()
+            if self.cleanup:
+                    os.remove(self.local_file)
+
+    def readable(self):
+        return True
+
+    def seekable(self):
+        return True
+
+    def writable(self):
+        return False
+
+    def read(self, __size=None):
+        if not self.local_file:
+            self.getFile()
+        output = self.local_file.read(__size)
+        return output
+
+    def readline(self, __size=None):
+        with self.getFile() as f:
+            output = f.readline(__size)
+        return output
+
+    def readlines(self, __hint=None):
+        if not self.local_file:
+            self.getFile()
+        output = self.local_file.readlines(__hint)
+        return output
+
+    def tell(self):
+        if not self.local_file:
+            self.getFile()
+        output = self.local_file.tell()
+        return output
+
+    def seek(self, __offset, __whence=None):
+        if not self.local_file:
+            self.getFile()
+        if __whence:
+            output = self.local_file.seek(__offset, __whence)
+        else:
+            output = self.local_file.seek(__offset)
+        return output

--- a/Algorithmia/datafile.py
+++ b/Algorithmia/datafile.py
@@ -242,9 +242,9 @@ def localPutHelper(path, contents):
         return dict(error=str(e))
 
 
-class AdvancedDatafile(DataFile, RawIOBase):
+class AdvancedDataFile(DataFile, RawIOBase):
     def __init__(self, client, dataUrl, cleanup=True):
-        super(AdvancedDatafile, self).__init__(client, dataUrl)
+        super(AdvancedDataFile, self).__init__(client, dataUrl)
         self.cleanup = cleanup
         self.local_file = None
 

--- a/Test/datafile_test.py
+++ b/Test/datafile_test.py
@@ -122,7 +122,7 @@ class AdvancedDataFileTest(unittest.TestCase):
 
     def test_get_nonexistant(self):
         try:
-            with self.client.file('data://.my/nonexistant/nonreal', advanced=True) as f:
+            with self.client.file('data://.my/nonexistant/nonreal') as f:
                 _ = f.read()
             retrieved_file = True
         except Exception as e:
@@ -130,7 +130,7 @@ class AdvancedDataFileTest(unittest.TestCase):
         self.assertFalse(retrieved_file)
 
     def test_get_str(self):
-        df = self.client.file('data://.my/nonexistant/nonreal', advanced=True)
+        df = self.client.file('data://.my/nonexistant/nonreal', cleanup=True)
         try:
             print(df.getString())
             retrieved_file = True

--- a/Test/datafile_test.py
+++ b/Test/datafile_test.py
@@ -8,7 +8,7 @@ import unittest, os, uuid
 import numpy as np
 import Algorithmia
 import json
-from Algorithmia.datafile import DataFile, LocalDataFile, AdvancedDatafile
+from Algorithmia.datafile import DataFile, LocalDataFile, AdvancedDataFile
 
 class DataFileTest(unittest.TestCase):
     def setUp(self):
@@ -140,7 +140,7 @@ class AdvancedDataFileTest(unittest.TestCase):
 
     def test_putJson_getJson(self):
         file = '.my/empty/test.json'
-        df = AdvancedDatafile(self.client,'data://'+file, cleanup=True)
+        df = AdvancedDataFile(self.client, 'data://' + file, cleanup=True)
         if sys.version_info[0] < 3:
             payload = {u"hello":u"world"}
         else:

--- a/Test/datafile_test.py
+++ b/Test/datafile_test.py
@@ -7,7 +7,7 @@ sys.path = ['../'] + sys.path
 import unittest, os, uuid
 import numpy as np
 import Algorithmia
-from Algorithmia.datafile import DataFile, LocalDataFile
+from Algorithmia.datafile import DataFile, LocalDataFile, AdvancedDatafile
 
 class DataFileTest(unittest.TestCase):
     def setUp(self):
@@ -112,6 +112,42 @@ class LocalFileTest(unittest.TestCase):
         # Check getFile
         txt = self.client.file(self.EXISTING_FILE).getFile().read()
         self.assertEqual(txt, self.EXISTING_TEXT)
+
+class AdvancedDataFileTest(unittest.TestCase):
+    def setUp(self):
+        self.client = Algorithmia.client()
+        if not self.client.dir("data://.my/empty").exists():
+            self.client.dir("data://.my/empty").create()
+
+    def test_get_nonexistant(self):
+        try:
+            with self.client.file('data://.my/nonexistant/nonreal', advanced=True) as f:
+                output = f.read()
+            retrieved_file = True
+        except Exception as e:
+            retrieved_file = False
+        self.assertFalse(retrieved_file)
+
+    def test_get_str(self):
+        df = self.client.file('data://.my/nonexistant/nonreal', advanced=True)
+        try:
+            print(df.getString())
+            retrieved_file = True
+        except Exception as e:
+            retrieved_file = False
+        self.assertFalse(retrieved_file)
+
+    def test_putJson_getJson(self):
+        file = '.my/empty/test.json'
+        df = AdvancedDatafile(self.client,'data://'+file, cleanup=True)
+        if sys.version_info[0] < 3:
+            payload = {u"hello":u"world"}
+        else:
+            payload = {"hello": "world"}
+        response = df.putJson(payload)
+        self.assertEqual(response.path,file)
+        result = df.read()
+        self.assertEqual(str(result), str(payload))
 
 if __name__ == '__main__':
     unittest.main()

--- a/Test/datafile_test.py
+++ b/Test/datafile_test.py
@@ -7,6 +7,7 @@ sys.path = ['../'] + sys.path
 import unittest, os, uuid
 import numpy as np
 import Algorithmia
+import json
 from Algorithmia.datafile import DataFile, LocalDataFile, AdvancedDatafile
 
 class DataFileTest(unittest.TestCase):
@@ -122,7 +123,7 @@ class AdvancedDataFileTest(unittest.TestCase):
     def test_get_nonexistant(self):
         try:
             with self.client.file('data://.my/nonexistant/nonreal', advanced=True) as f:
-                output = f.read()
+                _ = f.read()
             retrieved_file = True
         except Exception as e:
             retrieved_file = False
@@ -146,7 +147,8 @@ class AdvancedDataFileTest(unittest.TestCase):
             payload = {"hello": "world"}
         response = df.putJson(payload)
         self.assertEqual(response.path,file)
-        result = df.read()
+        result = json.loads(df.read())
+        self.assertDictEqual(result, payload)
         self.assertEqual(str(result), str(payload))
 
 if __name__ == '__main__':


### PR DESCRIPTION
As per requested by some users during algorithm development; it can be sometimes hard to understand the steps required to download a file and to load it into something like pytorch.
Previously this workflow was required

```python
client = Algorithmia.client(...)
file = client.file(...).getFile().name
model = torch.load(file)
```

That might seem trivial, but has caused some confusion amongst users; this change makes datafiles FileIO compliant and means we can skip a few steps:

```python
client = Algorithmia.client(...)
model = torch.load(client.file(...))
```
no getFile required, the local file connection is cleaned on leaving context; with the temporary file also automatically cleaned up.