### PR TITLE
ALGO-XXX adding better test coverage

### DIFF
--- a/Algorithmia/algorithm.py
+++ b/Algorithmia/algorithm.py
@@ -166,7 +166,7 @@ class Algorithm(object):
     def compile(self):
         try:
             # Compile algorithm
-            api_response = self.client.manageApi.algorithms_username_algoname_compile_post(self.username, self.algoname)
+            api_response = self.client.manageApi.compile_algorithm(self.username, self.algoname)
             return api_response
         except ApiException as e:
             error_message = json.loads(e.body)

--- a/Algorithmia/datafile.py
+++ b/Algorithmia/datafile.py
@@ -250,9 +250,10 @@ class AdvancedDataFile(DataFile, RawIOBase):
 
     def __del__(self):
         if self.local_file:
+            filepath = self.local_file.name
             self.local_file.close()
             if self.cleanup:
-                    os.remove(self.local_file)
+                    os.remove(filepath)
 
     def readable(self):
         return True
@@ -267,7 +268,7 @@ class AdvancedDataFile(DataFile, RawIOBase):
         if not self.local_file:
             self.local_file = self.getFile()
             output = self.local_file.read()
-        if __size:
+        elif __size:
             output = self.local_file.read(__size)
         else:
             output = self.local_file.read()

--- a/Test/client_test.py
+++ b/Test/client_test.py
@@ -9,63 +9,66 @@ sys.path = ['../'] + sys.path
 
 import unittest
 import Algorithmia
+from uuid import uuid4
 
 if sys.version_info.major == 3:
     unicode = str
 
 class ClientTest(unittest.TestCase):
     seed(datetime.now().microsecond)
-
-    username = "a_Mrtest"
-    org_name = "a_myOrg"
+    # due to legacy reasons, regular client tests are tested against api.algorithmia.com, whereas admin api tests are run
+    # against test.algorithmia.com.
+    admin_username = "a_Mrtest"
+    admin_org_name = "a_myOrg"
+    environment_id = "b4ffe0a8-1d34-44e3-90ba-bbe630bdd643"
 
     def setUp(self):
         self.admin_api_key = unicode(os.environ.get('ALGORITHMIA_A_KEY'))
+        self.regular_api_key = unicode(os.environ.get('ALGORITHMIA_API_KEY'))
 
-        self.username = self.username + str(int(random() * 10000))
-        self.org_name = self.org_name + str(int(random() * 10000))
-        self.c = Algorithmia.client(api_address="https://test.algorithmia.com",
-                                    api_key=self.admin_api_key)
+        self.admin_username = self.admin_username + str(int(random() * 10000))
+        self.admin_org_name = self.admin_org_name + str(int(random() * 10000))
+        self.admin_client = Algorithmia.client(api_address="https://test.algorithmia.com",
+                                               api_key=self.admin_api_key)
+        self.regular_client = Algorithmia.client(api_address='https://api.algorithmia.com',
+                                    api_key=self.regular_api_key)
 
     def test_create_user(self):
-        response = self.c.create_user(
-            {"username": self.username, "email": self.username + "@algo.com", "passwordHash": "",
+        response = self.admin_client.create_user(
+            {"username": self.admin_username, "email": self.admin_username + "@algo.com", "passwordHash": "",
              "shouldCreateHello": False})
 
         if type(response) is dict:
-            self.assertEqual(self.username, response['username'])
+            self.assertEqual(self.admin_username, response['username'])
         else:
             self.assertIsNotNone(response)
 
     def test_get_org_types(self):
-        response = self.c.get_org_types()
+        response = self.admin_client.get_org_types()
         self.assertTrue(len(response) > 0)
 
     def test_create_org(self):
-        response = self.c.create_org(
-            {"org_name": self.org_name, "org_label": "some label", "org_contact_name": "Some owner",
-             "org_email": self.org_name + "@algo.com", "type_id": "basic"})
+        response = self.admin_client.create_org(
+            {"org_name": self.admin_org_name, "org_label": "some label", "org_contact_name": "Some owner",
+             "org_email": self.admin_org_name + "@algo.com", "type_id": "basic"})
 
-        self.assertEqual(self.org_name, response[u'org_name'])
+        self.assertEqual(self.admin_org_name, response[u'org_name'])
 
     def test_get_org(self):
-        response = self.c.get_org("a_myOrg84")
+        response = self.admin_client.get_org("a_myOrg84")
         self.assertEqual("a_myOrg84", response['org_name'])
 
     def test_get_environment(self):
-        client = Algorithmia.client(api_key=unicode(os.environ.get('ALGORITHMIA_API_KEY')))
-        response = client.get_environment("python2")
+        response = self.admin_client.get_environment("python2")
 
         if u'error' not in response:
             self.assertTrue(response is not None and u'environments' in response)
 
     def test_get_build_logs(self):
-        client = Algorithmia.client(api_address='https://api.algorithmia.com',
-                                    api_key=unicode(os.environ.get('ALGORITHMIA_API_KEY')))
         user = unicode(os.environ.get('ALGO_USER_NAME'))
         algo = unicode('echo')
         algo_path = u'%s/%s' % (user, algo)
-        result = client.algo(algo_path).build_logs()
+        result = self.regular_client.algo(algo_path).build_logs()
 
         if u'error' in result:
             print(result)
@@ -74,7 +77,7 @@ class ClientTest(unittest.TestCase):
 
     def test_get_build_logs_no_ssl(self):
         client = Algorithmia.client(api_address='https://api.algorithmia.com',
-                                    api_key=unicode(os.environ.get('ALGORITHMIA_API_KEY')), ca_cert=False)
+                                    api_key=self.regular_api_key, ca_cert=False)
         user = unicode(os.environ.get('ALGO_USER_NAME'))
         algo = u'Echo'
         result = client.algo(user + '/' + algo).build_logs()
@@ -97,7 +100,7 @@ class ClientTest(unittest.TestCase):
             "resource_type": "organization"
         }
 
-        response = self.c.edit_org(org_name, obj)
+        response = self.admin_client.edit_org(org_name, obj)
         if type(response) is dict:
             print(response)
         else:
@@ -105,7 +108,7 @@ class ClientTest(unittest.TestCase):
 
     def test_get_template(self):
         filename = "./temptest"
-        response = self.c.get_template("36fd467e-fbfe-4ea6-aa66-df3f403b7132", filename)
+        response = self.admin_client.get_template("36fd467e-fbfe-4ea6-aa66-df3f403b7132", filename)
 
         if type(response) is dict:
             self.assertTrue(u'error' in response or u'message' in response)
@@ -117,7 +120,7 @@ class ClientTest(unittest.TestCase):
                 print(e)
 
     def test_get_supported_languages(self):
-        response = self.c.get_supported_languages()
+        response = self.admin_client.get_supported_languages()
         self.assertTrue(response is not None)
 
         if type(response) is not list:
@@ -127,7 +130,7 @@ class ClientTest(unittest.TestCase):
             self.assertTrue(response is not None and language_found)
 
     def test_invite_to_org(self):
-        response = self.c.invite_to_org("a_myOrg38", "a_Mrtest4")
+        response = self.admin_client.invite_to_org("a_myOrg38", "a_Mrtest4")
         if type(response) is dict:
             self.assertTrue(u'error' in response)
         else:
@@ -136,26 +139,76 @@ class ClientTest(unittest.TestCase):
     # This test will require updating after the /v1/organizations/{org_name}/errors endpoint has been
     # deployed to the remote environment.
     def test_get_organization_errors(self):
-        response = self.c.get_organization_errors(self.org_name)
+        response = self.admin_client.get_organization_errors(self.admin_org_name)
         self.assertTrue(response is not None)
 
         if type(response) is list:
             self.assertEqual(0, len(response), 'Received unexpected result, should have been 0.')
 
     def test_get_user_errors(self):
-        response = self.c.get_user_errors(self.username)
+        response = self.admin_client.get_user_errors(self.admin_username)
 
         self.assertTrue(response is not None)
         self.assertEqual(0, len(response))
 
     def test_get_algorithm_errors(self):
-        response = self.c.get_algorithm_errors('hello')
+        response = self.admin_client.get_algorithm_errors('hello')
         self.assertTrue(response is not None)
 
         if type(response) is dict:
             self.assertTrue(u'error' in response)
         else:
             self.assertEqual(404, response.status_code)
+
+
+    def test_algorithm_programmatic_create_process(self):
+        algorithm_name = "algo_" + str(uuid4()).split("-")[-1]
+        payload = "John"
+        expected_response = "hello John"
+        full_path = self.regular_client.username() + "/" + algorithm_name
+        details = {
+            "summary": "Example Summary",
+            "label": "QA",
+            "tagline": "Example Tagline"
+        }
+        settings = {
+            "source_visibility": "open",
+            "algorithm_environment": self.environment_id,
+            "license": "apl",
+            "network_access": "isolated",
+            "pipeline_enabled": False
+        }
+        created_algo = self.regular_client.algo(full_path)
+        response = created_algo.create(details=details,settings=settings)
+        self.assertEqual(response.name, algorithm_name)
+
+        # --- Creation complete, compiling
+
+        response = created_algo.compile()
+        git_hash = response.version_info.git_hash
+        algo_with_build = self.regular_client.algo(full_path + "/" + git_hash)
+        self.assertEqual(response.name, created_algo.algoname)
+
+        # --- compiling complete, now testing algorithm request
+        response = algo_with_build.pipe(payload).result
+        self.assertEqual(response, expected_response)
+
+        # --- testing complete, now publishing new release.
+
+        pub_settings = {"algorithm_callability": "private"}
+        pub_version_info = {
+                           "release_notes": "created programmatically",
+                           "sample_input": payload,
+                           "version_type": "minor"
+                       }
+        pub_details = {"label": "testing123"}
+
+        response = algo_with_build.publish(
+            details=pub_details,
+            settings=pub_settings,
+            version_info=pub_version_info
+        )
+        self.assertEqual(response.version_info.semantic_version, "0.1.0")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds test coverage to the following endpoints

algorithms/create
algorithms/compile
algorithms/info
algorithms/publish

This also fixes a bug with a previously released version.

~Currently depends on an environment_id variable which may change during redeploying of environments; may adjust this to be dynamic before submitting~ EDIT: we added an environment_id gathering script to `setup`.