### PR TITLE
ALGO-ADK updated to non-breaking version of adk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ enum-compat
 toml
 argparse
 algorithmia-api-client==1.5.1
-algorithmia-adk>=1.0.2,<1.1
+algorithmia-adk>=1.0.4,<1.1
 numpy<2
 uvicorn==0.14.0
 fastapi==0.65.2

--- a/requirements27.txt
+++ b/requirements27.txt
@@ -4,5 +4,5 @@ enum-compat
 toml
 argparse
 algorithmia-api-client==1.5.1
-algorithmia-adk>=1.0.2,<1.1
+algorithmia-adk>=1.0.4,<1.1
 numpy<2


### PR DESCRIPTION
Detected an issue with the ADK occasionally failing to read stdin and close the connection with langserver when load time exceptions fail.