### PR TITLE
Algo-XXX proide a getDir() path for Data Directories

### DIFF
--- a/Algorithmia/datadirectory.py
+++ b/Algorithmia/datadirectory.py
@@ -73,6 +73,17 @@ class DataDirectory(DataObject):
     def dirs(self):
         return self._get_directory_iterator(DataObjectType.directory)
 
+    def getDir(self):
+        directory = tempfile.mkdtemp()
+        for file in self.files():
+            correct_filename = file.getName()
+            correct_file_path = os.path.join(directory, correct_filename)
+            local_file = file.getFile(as_path=True)
+            print(correct_file_path)
+            os.rename(local_file, correct_file_path)
+        return directory
+
+
     def list(self):
         return self._get_directory_iterator()
 

--- a/Algorithmia/datadirectory.py
+++ b/Algorithmia/datadirectory.py
@@ -82,7 +82,6 @@ class DataDirectory(DataObject):
             os.rename(local_file, correct_file_path)
         return directory
 
-
     def list(self):
         return self._get_directory_iterator()
 

--- a/Algorithmia/datadirectory.py
+++ b/Algorithmia/datadirectory.py
@@ -79,7 +79,6 @@ class DataDirectory(DataObject):
             correct_filename = file.getName()
             correct_file_path = os.path.join(directory, correct_filename)
             local_file = file.getFile(as_path=True)
-            print(correct_file_path)
             os.rename(local_file, correct_file_path)
         return directory
 

--- a/Algorithmia/datafile.py
+++ b/Algorithmia/datafile.py
@@ -33,7 +33,7 @@ class DataFile(DataObject):
         return self.client.getHelper(self.url)
 
     # Get file from the data api
-    def getFile(self):
+    def getFile(self, as_path=False):
         exists, error = self.existsWithError()
         if not exists:
             raise DataApiError('unable to get file {} - {}'.format(self.path, error))
@@ -45,7 +45,10 @@ class DataFile(DataObject):
                     break
                 f.write(block)
             f.flush()
-        return open(f.name)
+        if as_path:
+            return f.name
+        else:
+            return open(f.name)
 
     def getName(self):
         _, name = getParentAndBase(self.path)

--- a/Test/datadirectory_test.py
+++ b/Test/datadirectory_test.py
@@ -95,7 +95,7 @@ class DataDirectoryTest(unittest.TestCase):
 
     def get_files(self, collectionName):
         dd = self.client.dir(collectionName)
-        if (dd.exists()):
+        if dd.exists():
             dd.delete(True)
 
         dd.create()

--- a/Test/datadirectory_test.py
+++ b/Test/datadirectory_test.py
@@ -93,11 +93,32 @@ class DataDirectoryTest(unittest.TestCase):
 
         dd.delete(True)
 
+    def get_files(self, collectionName):
+        dd = self.client.dir(collectionName)
+        if (dd.exists()):
+            dd.delete(True)
+
+        dd.create()
+
+        f1 = dd.file('a')
+        f1.put('data')
+
+        f2 = dd.file('b')
+        f2.put('data')
+
+        local_path = dd.getDir()
+        self.assertTrue(os.path.isfile(os.path.join(local_path, "a")))
+        self.assertTrue(os.path.isfile(os.path.join(local_path, "b")))
+
+
     def test_list_files_small_without_trailing_slash(self):
         self.list_files_small('data://.my/test_list_files_small')
 
     def test_list_files_small_with_trailing_slash(self):
         self.list_files_small('data://.my/test_list_files_small/')
+
+    def test_get_directory(self):
+        self.get_files("data://.my/test_list_files_small")
 
     def test_list_folders(self):
         dd = DataDirectory(self.client, 'data://.my/')


### PR DESCRIPTION
Multiple customers and users have complained over the lack of support regarding downloading an entire data directory at once; preserving filenames and internal files. This PR adds a method to the data directory called `getDir()`; this provides a temporary file in the users scratch space that preserves the heirarchy and datafiles + correct names of all files contained within.
This PR has not added this functionality to the LocalDirectory system; and has been tested to function with S3 buckets
