### PR TITLE
removal of api-client utilization for algo.publish

### DIFF
--- a/Algorithmia/algorithm.py
+++ b/Algorithmia/algorithm.py
@@ -69,18 +69,19 @@ class Algorithm(object):
 
     # Publish an algorithm
     def publish(self, details={}, settings={}, version_info={}):
-        detailsObj = Details(**details)
-        settingsObj = SettingsPublish(**settings)
-        versionRequestObj = VersionInfoPublish(**version_info)
-        publish_parameters = {"details": detailsObj, "settings": settingsObj, "version_info": versionRequestObj}
-        version_request = VersionRequest(**publish_parameters) # VersionRequest | Publish Version Request
-        try:
-            # Publish Algorithm
-            api_response = self.client.manageApi.publish_algorithm(self.username, self.algoname, version_request)
-            return api_response
-        except ApiException as e:
-            error_message = json.loads(e.body)
-            raise raiseAlgoApiError(error_message)
+        # detailsObj = Details(**details)
+        # settingsObj = SettingsPublish(**settings)
+        # versionRequestObj = VersionInfoPublish(**version_info)
+        # publish_parameters = {"details": detailsObj, "settings": settingsObj, "version_info": versionRequestObj}
+        # version_request = VersionRequest(**publish_parameters) # VersionRequest | Publish Version Request
+        publish_parameters = {"details": details, "settings": settings, "version_info": version_info}
+        url = "/v1/algorithms/"+self.username+"/"+self.algoname + "/versions"
+        print(publish_parameters)
+        api_response = self.client.postJsonHelper(url, publish_parameters, parse_response_as_json=True, **self.query_parameters)
+        return api_response
+        # except ApiException as e:
+        #     error_message = json.loads(e.body)
+        #     raise raiseAlgoApiError(error_message)
 
     def builds(self, limit=56, marker=None):
         try:

--- a/Test/client_test.py
+++ b/Test/client_test.py
@@ -213,7 +213,7 @@ class ClientTest(unittest.TestCase):
             settings=pub_settings,
             version_info=pub_version_info
         )
-        self.assertEqual(response.version_info.semantic_version, "0.1.0", "Publishing failed, semantic version is not correct.")
+        self.assertEqual(response["version_info"]["semantic_version"], "0.1.0", "Publishing failed, semantic version is not correct.")
 
         # --- publishing complete, getting additional information
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ enum-compat
 toml
 argparse
 algorithmia-api-client==1.5.1
-algorithmia-adk>=1.0.4,<1.1
+algorithmia-adk>=1.1,<1.2
 numpy<2
 uvicorn==0.14.0
 fastapi==0.65.2

--- a/requirements27.txt
+++ b/requirements27.txt
@@ -4,5 +4,5 @@ enum-compat
 toml
 argparse
 algorithmia-api-client==1.5.1
-algorithmia-adk>=1.0.4,<1.1
+algorithmia-adk>=1.1,<1.2
 numpy<2

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'toml',
         'argparse',
         'algorithmia-api-client==1.5.1',
-        'algorithmia-adk>=1.0.2,<1.1'
+        'algorithmia-adk>=1.1,<1.2'
     ],
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
As part of our efforts to remove segments of the api-client from the python mgmt api; and as a request by a customer, we've hardcoded the post request required for the algo publish workflow. This has been tested and should allow the customer to proceed with other work.

To test, compile an existing algorithm, and run `algo.publish(version_info={"version_type": "minor", "release_notes": "automatically deployed by CI"}, settings={"royalty_microcredits": 0}, details={"label": "CICD"})`

Also included ADK Model Manifest and changes to load function workflow from the ADK in this PR