### PR TITLE
update requirements to satisfy actual ADK dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ enum-compat
 toml
 argparse
 algorithmia-api-client==1.5.1
-algorithmia-adk>=1.1,<1.2
+algorithmia-adk>=1.2,<1.3
 numpy<2
 uvicorn==0.14.0
 fastapi==0.65.2

--- a/requirements27.txt
+++ b/requirements27.txt
@@ -4,5 +4,5 @@ enum-compat
 toml
 argparse
 algorithmia-api-client==1.5.1
-algorithmia-adk>=1.1,<1.2
+algorithmia-adk>=1.2,<1.3
 numpy<2


### PR DESCRIPTION
current requirements.txt and requirements27.txt files are not tracking the correct versions of the adk sibling package. This PR corrects that.