### PR TITLE
added get and set secrets endpoints for python client

### DIFF
--- a/Algorithmia/algorithm.py
+++ b/Algorithmia/algorithm.py
@@ -39,7 +39,8 @@ class Algorithm(object):
         return self
 
     def get_algorithm_id(self):
-        url = "/v1/algorithms/" + self.username + "/" + self.algoname
+        url = '/v1/algorithms/' + self.username + '/' + self.algoname
+        print(url)
         api_response = self.client.getJsonHelper(url)
         if 'id' in api_response:
             return api_response['id']
@@ -76,7 +77,6 @@ class Algorithm(object):
         print(create_parameters)
         api_response = self.client.postJsonHelper(url, create_parameters, parse_response_as_json=True)
         return api_response
-
 
 
     # Create a new algorithm

--- a/Algorithmia/algorithm.py
+++ b/Algorithmia/algorithm.py
@@ -38,6 +38,43 @@ class Algorithm(object):
         self.query_parameters.update(query_parameters)
         return self
 
+    def get_algorithm_id(self):
+        url = "/v1/algorithms/" + self.username + "/" + self.algoname
+        api_response = self.client.getJsonHelper(url)
+        if 'id' in api_response:
+            return api_response['id']
+        else:
+            raise Exception("field 'id' not found in response: ", api_response)
+
+
+    def get_secrets(self):
+        algorithm_id = self.get_algorithm_id()
+        url = "/v1/algorithms/" + algorithm_id + "/secrets"
+        api_response = self.client.getJsonHelper(url)
+        return api_response
+
+
+    def set_secret(self, short_name, secret_key, secret_value, description=None):
+        algorithm_id = self.get_algorithm_id()
+        url = "/v1/algorithms/" + algorithm_id + "/secrets"
+        secret_providers = self.client.get_secret_providers()
+        provider_id = secret_providers[0]['id']
+
+        create_parameters = {
+            "owner_type": "algorithm",
+            "owner_id": algorithm_id,
+            "short_name": short_name,
+            "provider_id": provider_id,
+            "secret_key": secret_key,
+            "secret_value": secret_value,
+        }
+        if description:
+            create_parameters['description'] = description
+        api_response = self.client.postJsonHelper(url, create_parameters, parse_response_as_json=True)
+        return api_response
+
+
+
     # Create a new algorithm
     def create(self, details, settings, version_info=None, source=None, scmsCredentials=None):
         url = "/v1/algorithms/" + self.username

--- a/Algorithmia/algorithm.py
+++ b/Algorithmia/algorithm.py
@@ -70,6 +70,10 @@ class Algorithm(object):
         }
         if description:
             create_parameters['description'] = description
+        else:
+            create_parameters['description'] = " "
+
+        print(create_parameters)
         api_response = self.client.postJsonHelper(url, create_parameters, parse_response_as_json=True)
         return api_response
 

--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -177,6 +177,11 @@ class Client(object):
         response = self.getHelper(url)
         return response.json()
 
+    def get_secret_providers(self):
+        url = "/v1/secret-provider"
+        api_response = self.getJsonHelper(url)
+        return api_response
+
     def get_organization_errors(self, org_name):
         """Gets the errors for the organization.
 

--- a/Test/api/app.py
+++ b/Test/api/app.py
@@ -444,3 +444,99 @@ async def get_environments_by_lang(language):
             }
         ]
     }
+
+
+@regular_app.get("/v1/secret-provider")
+async def get_service_providers():
+    return [
+        {
+            "id": "dee00b6c-05c4-4de7-98d8-e4a3816ed75f",
+            "name": "algorithmia_internal_secret_provider",
+            "description": "Internal Secret Provider",
+            "moduleName": "module",
+            "factoryClassName": "com.algorithmia.plugin.sqlsecretprovider.InternalSecretProviderFactory",
+            "interfaceVersion": "1.0",
+            "isEnabled": True,
+            "isDefault": True,
+            "created": "2021-03-11T20:42:23Z",
+            "modified": "2021-03-11T20:42:23Z"
+        }
+    ]
+
+
+@regular_app.get("/v1/algorithms/{algorithm_id}/secrets")
+async def get_secrets_for_algorithm(algorithm_id):
+    return {
+        "secrets": [
+            {
+                "id": "45e97c47-3ae6-46be-87ee-8ab23746706b",
+                "short_name": "MLOPS_SERVICE_URL",
+                "description": "",
+                "secret_key": "MLOPS_SERVICE_URL",
+                "owner_type": "algorithm",
+                "owner_id": "fa2cd80b-d22a-4548-b16a-45dbad2d3499",
+                "provider_id": "dee00b6c-05c4-4de7-98d8-e4a3816ed75f",
+                "created": "2022-07-22T14:36:01Z",
+                "modified": "2022-07-22T14:36:01Z"
+            },
+            {
+                "id": "50dca60e-317f-4582-8854-5b83b4d182d0",
+                "short_name": "deploy_id",
+                "description": "",
+                "secret_key": "DEPLOYMENT_ID",
+                "owner_type": "algorithm",
+                "owner_id": "fa2cd80b-d22a-4548-b16a-45dbad2d3499",
+                "provider_id": "dee00b6c-05c4-4de7-98d8-e4a3816ed75f",
+                "created": "2022-07-21T19:04:31Z",
+                "modified": "2022-07-21T19:04:31Z"
+            },
+            {
+                "id": "5a75cdc8-ecc8-4715-8c4b-8038991f1608",
+                "short_name": "model_path",
+                "description": "",
+                "secret_key": "MODEL_PATH",
+                "owner_type": "algorithm",
+                "owner_id": "fa2cd80b-d22a-4548-b16a-45dbad2d3499",
+                "provider_id": "dee00b6c-05c4-4de7-98d8-e4a3816ed75f",
+                "created": "2022-07-21T19:04:31Z",
+                "modified": "2022-07-21T19:04:31Z"
+            },
+            {
+                "id": "80e51ed3-f6db-419d-9349-f59f4bbfdcbb",
+                "short_name": "model_id",
+                "description": "",
+                "secret_key": "MODEL_ID",
+                "owner_type": "algorithm",
+                "owner_id": "fa2cd80b-d22a-4548-b16a-45dbad2d3499",
+                "provider_id": "dee00b6c-05c4-4de7-98d8-e4a3816ed75f",
+                "created": "2022-07-21T19:04:30Z",
+                "modified": "2022-07-21T19:04:30Z"
+            },
+            {
+                "id": "8773c654-ea2f-4ac5-9ade-55dfc47fec9d",
+                "short_name": "datarobot_api_token",
+                "description": "",
+                "secret_key": "DATAROBOT_MLOPS_API_TOKEN",
+                "owner_type": "algorithm",
+                "owner_id": "fa2cd80b-d22a-4548-b16a-45dbad2d3499",
+                "provider_id": "dee00b6c-05c4-4de7-98d8-e4a3816ed75f",
+                "created": "2022-07-21T19:04:31Z",
+                "modified": "2022-07-21T19:04:31Z"
+            }
+        ]
+    }
+
+
+@regular_app.post("/v1/algorithms/{algorithm_id}/secrets")
+async def set_algorithm_secret(algorithm_id):
+    return {
+   "id":"959af771-7cd8-4981-91c4-70def15bbcdc",
+   "short_name":"tst",
+   "description":"",
+   "secret_key":"test",
+   "owner_type":"algorithm",
+   "owner_id":"fa2cd80b-d22a-4548-b16a-45dbad2d3499",
+   "provider_id":"dee00b6c-05c4-4de7-98d8-e4a3816ed75f",
+   "created":"2022-07-22T18:28:42Z",
+   "modified":"2022-07-22T18:28:42Z"
+}

--- a/Test/api/app.py
+++ b/Test/api/app.py
@@ -60,7 +60,7 @@ async def process_hello_world(request: Request, username, algoname, githash):
 
 ### Algorithm Routes
 @regular_app.get('/v1/algorithms/{username}/{algoname}')
-async def process_get_algo(request: Request, username, algoname):
+async def process_get_algo(username, algoname):
     if algoname == "echo" and username == 'quality':
         return {"id": "21df7a38-eab8-4ac8-954c-41a285535e69", "name": "echo",
                 "details": {"summary": "", "label": "echo", "tagline": ""},

--- a/Test/regular/algo_test.py
+++ b/Test/regular/algo_test.py
@@ -20,15 +20,15 @@ if sys.version_info.major >= 3:
 
         def test_call_customCert(self):
             result = self.client.algo('quality/echo').pipe(bytearray('foo', 'utf-8'))
-            self.assertEquals('binary', result.metadata.content_type)
-            self.assertEquals(bytearray('foo', 'utf-8'), result.result)
+            self.assertEqual('binary', result.metadata.content_type)
+            self.assertEqual(bytearray('foo', 'utf-8'), result.result)
 
 
 
         def test_normal_call(self):
             result = self.client.algo('quality/echo').pipe("foo")
-            self.assertEquals("text", result.metadata.content_type)
-            self.assertEquals("foo", result.result)
+            self.assertEqual("text", result.metadata.content_type)
+            self.assertEqual("foo", result.result)
 
         def test_async_call(self):
             result = self.client.algo('quality/echo').set_options(output=OutputType.void).pipe("foo")
@@ -37,20 +37,20 @@ if sys.version_info.major >= 3:
 
         def test_raw_call(self):
             result = self.client.algo('quality/echo').set_options(output=OutputType.raw).pipe("foo")
-            self.assertEquals("foo", result)
+            self.assertEqual("foo", result)
 
         def test_dict_call(self):
             result = self.client.algo('quality/echo').pipe({"foo": "bar"})
-            self.assertEquals("json", result.metadata.content_type)
-            self.assertEquals({"foo": "bar"}, result.result)
+            self.assertEqual("json", result.metadata.content_type)
+            self.assertEqual({"foo": "bar"}, result.result)
 
         def test_algo_exists(self):
             result = self.client.algo('quality/echo').exists()
-            self.assertEquals(True, result)
+            self.assertEqual(True, result)
 
         def test_algo_no_exists(self):
             result = self.client.algo('quality/not_echo').exists()
-            self.assertEquals(False, result)
+            self.assertEqual(False, result)
 
         #TODO: add more coverage examples to check kwargs
         def test_get_versions(self):
@@ -58,19 +58,19 @@ if sys.version_info.major >= 3:
             self.assertTrue('results' in result)
             self.assertTrue('version_info' in result['results'][0])
             self.assertTrue('semantic_version' in result['results'][0]['version_info'])
-            self.assertEquals('0.1.0', result['results'][0]['version_info']['semantic_version'])
+            self.assertEqual('0.1.0', result['results'][0]['version_info']['semantic_version'])
 
         def test_text_unicode(self):
             telephone = u"\u260E"
             # Unicode input to pipe()
             result1 = self.client.algo('quality/echo').pipe(telephone)
-            self.assertEquals('text', result1.metadata.content_type)
-            self.assertEquals(telephone, result1.result)
+            self.assertEqual('text', result1.metadata.content_type)
+            self.assertEqual(telephone, result1.result)
 
             # Unicode return in .result
             result2 = self.client.algo('quality/echo').pipe(result1.result)
-            self.assertEquals('text', result2.metadata.content_type)
-            self.assertEquals(telephone, result2.result)
+            self.assertEqual('text', result2.metadata.content_type)
+            self.assertEqual(telephone, result2.result)
             
         def test_algo_info(self):
             result = self.client.algo('quality/echo').info()
@@ -177,9 +177,6 @@ if sys.version_info.major >= 3:
 
             self.assertEqual(response['version_info']['semantic_version'], "0.1.0", "information is incorrect")
 
-        def test_get_secrets(self):
-            response = self.client.algo("quality/echo").get_secrets()
-            self.assertEquals(len(response['secrets']), 5)
 
         def test_set_secret(self):
             short_name = "tst"
@@ -199,8 +196,8 @@ else:
             open("./test.pem", 'w')
             c = Algorithmia.client(ca_cert="./test.pem")
             result = c.algo('quality/echo').pipe(bytearray('foo', 'utf-8'))
-            self.assertEquals('binary', result.metadata.content_type)
-            self.assertEquals(bytearray('foo', 'utf-8'), result.result)
+            self.assertEqual('binary', result.metadata.content_type)
+            self.assertEqual(bytearray('foo', 'utf-8'), result.result)
             try:
                 os.remove("./test.pem")
             except OSError as e:
@@ -208,8 +205,8 @@ else:
 
         def test_call_binary(self):
             result = self.client.algo('quality/echo').pipe(bytearray('foo', 'utf-8'))
-            self.assertEquals('binary', result.metadata.content_type)
-            self.assertEquals(bytearray('foo', 'utf-8'), result.result)
+            self.assertEqual('binary', result.metadata.content_type)
+            self.assertEqual(bytearray('foo', 'utf-8'), result.result)
 
         def test_async_call(self):
             result = self.client.algo('quality/echo').set_options(output=OutputType.void).pipe("foo")
@@ -218,7 +215,7 @@ else:
 
         def test_raw_call(self):
             result = self.client.algo('quality/echo').set_options(output=OutputType.raw).pipe("foo")
-            self.assertEquals("foo", result)
+            self.assertEqual("foo", result)
 
         #TODO: add more coverage examples to check kwargs
         def test_get_versions(self):
@@ -226,20 +223,20 @@ else:
             self.assertTrue('results' in result)
             self.assertTrue('version_info' in result['results'][0])
             self.assertTrue('semantic_version' in result['results'][0]['version_info'])
-            self.assertEquals('0.1.0', result['results'][0]['version_info']['semantic_version'])
+            self.assertEqual('0.1.0', result['results'][0]['version_info']['semantic_version'])
 
         def test_text_unicode(self):
             telephone = u"\u260E"
 
             # Unicode input to pipe()
             result1 = self.client.algo('quality/echo').pipe(telephone)
-            self.assertEquals('text', result1.metadata.content_type)
-            self.assertEquals(telephone, result1.result)
+            self.assertEqual('text', result1.metadata.content_type)
+            self.assertEqual(telephone, result1.result)
 
             # Unicode return in .result
             result2 = self.client.algo('quality/echo').pipe(result1.result)
-            self.assertEquals('text', result2.metadata.content_type)
-            self.assertEquals(telephone, result2.result)
+            self.assertEqual('text', result2.metadata.content_type)
+            self.assertEqual(telephone, result2.result)
 
 
         def test_get_scm_status(self):

--- a/Test/regular/algo_test.py
+++ b/Test/regular/algo_test.py
@@ -23,6 +23,8 @@ if sys.version_info.major >= 3:
             self.assertEquals('binary', result.metadata.content_type)
             self.assertEquals(bytearray('foo', 'utf-8'), result.result)
 
+
+
         def test_normal_call(self):
             result = self.client.algo('quality/echo').pipe("foo")
             self.assertEquals("text", result.metadata.content_type)
@@ -174,6 +176,19 @@ if sys.version_info.major >= 3:
             response = created_algo.info(git_hash)
 
             self.assertEqual(response['version_info']['semantic_version'], "0.1.0", "information is incorrect")
+
+        def test_get_secrets(self):
+            response = self.client.algo("quality/echo").get_secrets()
+            self.assertEquals(len(response['secrets']), 5)
+
+        def test_set_secret(self):
+            short_name = "tst"
+            secret_key = "test_key"
+            secret_value = "test_value"
+            description = "loreum epsum"
+            response = self.client.algo("quality/echo").set_secret(short_name, secret_key, secret_value, description)
+            self.assertEqual(response['id'], "959af771-7cd8-4981-91c4-70def15bbcdc", "invalid ID for created secret")
+
 
 else:
     class AlgoTest(unittest.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ enum-compat
 toml
 argparse
 algorithmia-api-client==1.5.1
-algorithmia-adk>=1.2,<1.3
+algorithmia-adk>=1.2,<1.4
 numpy<2
 uvicorn==0.14.0
 fastapi==0.65.2

--- a/requirements27.txt
+++ b/requirements27.txt
@@ -4,5 +4,5 @@ enum-compat
 toml
 argparse
 algorithmia-api-client==1.5.1
-algorithmia-adk>=1.2,<1.3
+algorithmia-adk>=1.2,<1.4
 numpy<2

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'toml',
         'argparse',
         'algorithmia-api-client==1.5.1',
-        'algorithmia-adk>=1.2,<1.3'
+        'algorithmia-adk>=1.2,<1.4'
     ],
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
this adds the `client.algo(..).get_secrets()` and `client.algo(..).set_secret(..)` endpoints, used by the 
https://gist.github.com/zeryx/5d50851d2aeb4c927b75dea8fa36a04e project

tested against marketplace and seems to work!
All fields are required, otherwise you get a malformed json parsing error (this is a bug serverside, will be reporting as a bug)