### PR TITLE
added a retry mechanic to PostJsonHelper to avoid 400 error issues

### DIFF
--- a/Algorithmia/algorithm.py
+++ b/Algorithmia/algorithm.py
@@ -106,7 +106,7 @@ class Algorithm(object):
         url = "/v1/algorithms/" + self.username + "/" + self.algoname + "/versions"
         publish_parameters = {"details": details, "settings": settings,
                               "version_info": version_info, "source": source, "scmsCredentials": scmsCredentials}
-        api_response = self.client.postJsonHelper(url, publish_parameters, parse_response_as_json=True)
+        api_response = self.client.postJsonHelper(url, publish_parameters, parse_response_as_json=True, retry=True)
         return api_response
 
     def get_builds(self, limit=56, marker=None):
@@ -180,7 +180,7 @@ class Algorithm(object):
     def compile(self):
         # Compile algorithm
         url = '/v1/algorithms/' + self.username + '/' + self.algoname + '/compile'
-        response = self.client.postJsonHelper(url, {}, parse_response_as_json=True)
+        response = self.client.postJsonHelper(url, {}, parse_response_as_json=True, retry=True)
         return response
 
     # Pipe an input into this algorithm

--- a/Algorithmia/client.py
+++ b/Algorithmia/client.py
@@ -16,7 +16,6 @@ import os
 from time import time
 
 
-
 class Client(object):
     'Algorithmia Common Library'
 
@@ -231,7 +230,7 @@ class Client(object):
         return Insights(insights)
 
     # Used internally to post json to the api and parse json response
-    def postJsonHelper(self, url, input_object, parse_response_as_json=True, **query_parameters):
+    def postJsonHelper(self, url, input_object, parse_response_as_json=True, retry=False, **query_parameters):
         headers = {}
         if self.apiKey is not None:
             headers['Authorization'] = self.apiKey
@@ -263,6 +262,8 @@ class Client(object):
                     return response
             else:
                 return response
+        elif retry:
+            return self.postJsonHelper(url, input_object, parse_response_as_json, False, **query_parameters)
         else:
             raise raiseAlgoApiError(response)
 
@@ -292,7 +293,6 @@ class Client(object):
             if response.content is not None:
                 response = response.json()
             raise raiseAlgoApiError(response)
-
 
     def getStreamHelper(self, url, **query_parameters):
         headers = {}

--- a/Test/api/app.py
+++ b/Test/api/app.py
@@ -230,9 +230,16 @@ async def compile_algorithm(username, algoname):
         "resource_type": "algorithm"
     }
 
+fail_cnt = 0
 
 @regular_app.post("/v1/algorithms/{username}/{algoname}/versions")
 async def publish_algorithm(request: Request, username, algoname):
+    global fail_cnt
+    if "failonce" == algoname and fail_cnt == 0:
+        fail_cnt +=1
+        return JSONResponse(content="This is an expected failure mode, try again", status_code=400)
+    elif "failalways" == algoname:
+        return JSONResponse(status_code=500)
     return {"id": "2938ca9f-54c8-48cd-b0d0-0fb7f2255cdc", "name": algoname,
             "details": {"summary": "Example Summary", "label": "QA", "tagline": "Example Tagline"},
             "settings": {"algorithm_callability": "private", "source_visibility": "open",

--- a/Test/regular/algo_failure_test.py
+++ b/Test/regular/algo_failure_test.py
@@ -28,3 +28,15 @@ if sys.version_info[0] >= 3:
                 result = e
                 pass
             self.assertEqual(str(self.error_message), str(result))
+
+        def test_retry_on_400_error_publish(self):
+            result = self.client.algo("util/failonce").publish()
+            self.assertEqual(result['version_info']['semantic_version'], "0.1.0")
+
+        def test_throw_on_always_500_publish(self):
+            try:
+                result = self.client.algo("util/failalways").publish()
+            except Exception as e:
+                result = e
+                pass
+            self.assertEqual(str(self.error_message), str(result))


### PR DESCRIPTION
In some instances, the `/compile` and `publish` endpoints may fail with a 400 error if interacted with too quickly or based off of the order of operations in a stateful operation. In order to get around this quickly, this fix simply allows for the `publish` and `compile` endpoints to retry once, which may fix some state problems that affect user use cases. Not a long term solution, but should work for the moment.